### PR TITLE
Add 'data-language' as alternative for 'language' attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ A small plugin that allows you to use the Monaco Editor in your reveal.js presen
     ```html
     <section>
       <h2>My Code</h2>
-      <!-- specifying the language below is optional, will fall back to default -->
+      <!-- specifying the language below is optional, will fall back to default 
+          (attribute name 'data-language' will also work as an alternative for valid HTML) -->
       <pre><code class="monaco" language="javascript">
     function helloWorld() {
       console.log('hello, world!')

--- a/plugin.js
+++ b/plugin.js
@@ -102,7 +102,7 @@ export class MonacoPlugin {
         ).trimStart();
         codeBlock.innerHTML = "";
         const language =
-          codeBlock.getAttribute("language") || this.options.defaultLanguage;
+          codeBlock.getAttribute("language") || codeBlock.getAttribute("data-language") || this.options.defaultLanguage;
         this.activeEditor = this.monaco.editor.create(codeBlock, {
           value: initialCode,
           language: language,


### PR DESCRIPTION
First of all, thanks for your work, this plugin is really helpful to me!

It would be great if 'data-language' would be supported as an alternative to 'language', as the 'language' attribute is not valid HTML (which might be perfectly OK, depending on the use case).

The suggested code extension adds 'data-language' as an optional alternative, retaining 'language' for backward compatibility. I also extended the code example in README.md with a comment hinting towards 'data-language'.

Attached you find a small reveal test case:
[index.html.zip](https://github.com/joeskeen/reveal-monaco/files/13600697/index.html.zip)
