### PR TITLE
Add possibility for setting monaco editor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ A small plugin that allows you to use the Monaco Editor in your reveal.js presen
         hash: true,
 
         monaco: {
-          defaultLanguage: 'python' // optional, defaults to 'javascript'
+          defaultLanguage: 'python', // optional, defaults to 'javascript'
+          editorOptions: { // optional monaco options as per https://microsoft.github.io/monaco-editor/typedoc/variables/editor.EditorOptions.html
+            automaticLayout: true,
+             // ...
+          }
         },
 
         // Learn about plugins: https://revealjs.com/plugins/

--- a/plugin.js
+++ b/plugin.js
@@ -106,6 +106,7 @@ export class MonacoPlugin {
         this.activeEditor = this.monaco.editor.create(codeBlock, {
           value: initialCode,
           language: language,
+          ...this.options.editorOptions
         });
       }
     }

--- a/plugin.js
+++ b/plugin.js
@@ -104,9 +104,9 @@ export class MonacoPlugin {
         const language =
           codeBlock.getAttribute("language") || this.options.defaultLanguage;
         this.activeEditor = this.monaco.editor.create(codeBlock, {
+          ...this.options.editorOptions,
           value: initialCode,
-          language: language,
-          ...this.options.editorOptions
+          language: language
         });
       }
     }


### PR DESCRIPTION
I suggest to add an additional configuration setting (in the code change I called it 'editorOptions') that allows passing monaco editor options (such as hiding the minimap, enabling word wrap) as per [https://microsoft.github.io/monaco-editor/typedoc/variables/editor.EditorOptions.html](https://microsoft.github.io/monaco-editor/typedoc/variables/editor.EditorOptions.html).

I also extended the documentation correspondingly.

Attached you find a small reveal test case:
[index.html.zip](https://github.com/joeskeen/reveal-monaco/files/13601120/index.html.zip)
