### PR TITLE
Event for accessing editor contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ A small plugin that allows you to use the Monaco Editor in your reveal.js presen
 * To access editor contents, you can listen to the `reveal-monaco-content-change` event:
     ```javascript
     window.addEventListener("reveal-monaco-content-change", (event) => {
-			let codeValue = event.detail.textContent;
-		});
+      let codeValue = event.detail.textContent;
+    });
     ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ A small plugin that allows you to use the Monaco Editor in your reveal.js presen
       background-color: white;
     }
     ```
+* To access editor contents, you can listen to the `reveal-monaco-content-change` event:
+    ```javascript
+    window.addEventListener("reveal-monaco-content-change", (event) => {
+			let codeValue = event.detail.textContent;
+		});
+    ```
 
 ## Requirements
 

--- a/plugin.js
+++ b/plugin.js
@@ -108,6 +108,13 @@ export class MonacoPlugin {
           value: initialCode,
           language: language
         });
+
+        this.activeEditor.getModel().onDidChangeContent(e => {
+          const contentChangeEvent = new CustomEvent("reveal-monaco-content-change", { detail: { textContent: this.activeEditor.getModel().getValue() } });
+          window.dispatchEvent(contentChangeEvent);
+        });
+        // dispatch event for initial display of the editor
+        window.dispatchEvent(new CustomEvent("reveal-monaco-content-change", { detail: { textContent: this.activeEditor.getModel().getValue() } }));
       }
     }
   }


### PR DESCRIPTION
Hi @joeskeen, I created a clean branch for the change we discussed in issue #3. I also extended the documentation correspondingly. 

Attached you find a working reveal test case:
[contentChangeEvents.zip](https://github.com/joeskeen/reveal-monaco/files/13670798/contentChangeEvents.zip)
