### PR TITLE
Use reveal ready-event for initialisation

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -37,7 +37,7 @@ export class MonacoPlugin {
     this.deck.on("slidechanged", (x) => this.onSlideChanged(x));
 
     // see if there is an editor on the initial slide
-    this.onSlideChanged();
+    this.deck.on("ready", _ => this.onSlideChanged());
   }
 
   loadScript(url, callback) {


### PR DESCRIPTION
The Reveal state isn't fully loaded during the plugin initialization, which prevents the code from being interpreted on the first slide. This update resolves the issue.